### PR TITLE
update service doc to be consistent with parser

### DIFF
--- a/define/fsd.md
+++ b/define/fsd.md
@@ -40,7 +40,7 @@ service MyApi
 }
 ```
 
-It is also possible to omit the curly braces around the service members and instead use a semicolor after the service name.
+It is also possible to omit the curly braces around the service members and instead use a semicolon after the service name.
 
 ```
 [http(url: "https://api.example.com/v1/")]

--- a/define/fsd.md
+++ b/define/fsd.md
@@ -40,6 +40,20 @@ service MyApi
 }
 ```
 
+It is also possible to omit the curly braces around the service members and instead use a semicolor after the service name.
+
+```
+[http(url: "https://api.example.com/v1/")]
+[info(version: 2.1.3)]
+service MyApi;
+
+method myMethod { … }: { … }
+data MyData { … }
+enum MyEnum { … }
+…
+
+```
+
 #### HTTP
 
 The `url` parameter of the `http` attribute indicates the base URL where the HTTP service lives. The trailing slash is optional. If the attribute or its parameter is omitted, the client will have to provide the base URL.


### PR DESCRIPTION
It looks like this is intentionally supported in the parser https://github.com/FacilityApi/Facility/blob/448d3c1aeed8a8988b0040e6e2555092e9b75ae9/src/Facility.Definition/Fsd/FsdParsers.cs#L197